### PR TITLE
Configure build to publish nugets on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
-      - name: Calculate application version
-        id: build-version
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const toStrip = "refs/tags/v";
-            return context.ref.substring(toStrip.length)
-          result-encoding: string
-      - name: Print version
-        run: echo "${{ steps.build-version.outputs.result }}"
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -37,6 +27,8 @@ jobs:
     environment: nuget
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      id-token: write  # enable GitHub OIDC token issuance for this job
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
@@ -60,3 +52,13 @@ jobs:
         run: dotnet build -c RELEASE -p:ContinuousIntegrationBuild=true -p:version=${{ steps.build-version.outputs.result }} --no-restore
       - name: Create nuget package
         run: dotnet pack -c RELEASE --no-build -p:packageVersion=${{ steps.build-version.outputs.result }} -p:RepositoryBranch=${GITHUB_REF#refs/*/} -p:RepositoryCommit=${GITHUB_SHA} --no-restore
+
+      # https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing#policies-pending-full-activation  
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Publish package to nuget
+        run: dotnet nuget push "${GITHUB_WORKSPACE}/src/Thd/nupkg/thd.${{ steps.build-version.outputs.result }}.nupkg" --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/src/Thd/Thd.csproj
+++ b/src/Thd/Thd.csproj
@@ -18,6 +18,10 @@
         <RepositoryUrl>https://github.com/ViaEuropa/thd.git</RepositoryUrl>
         <PackageIcon>icon.png</PackageIcon>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    </PropertyGroup>
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="/"/>
         <None Include="images/icon.png" Pack="true" PackagePath="/"/>


### PR DESCRIPTION
Uses [trusted publising](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing#policies-pending-full-activation) to upload nugets when we're doing a release. So we don't need any long lived keys.

Depends on https://github.com/ViaEuropa/thd/pull/2