### PR TITLE
Add experimental filtering of requests and responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # dotenv files
 .env
+.envrc
 
 # User-specific files
 *.rsuser

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,12 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Scriban" Version="6.4.0" />
     <PackageVersion Include="Sep" Version="0.11.3" />
+    <PackageVersion Include="Spectre.Console" Version="0.53.0" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.53.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.2.25502.107" />
     <PackageVersion Include="SystemTextJson.JsonDiffPatch" Version="2.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Thd/Commands/Compare/CompareCommand.cs
+++ b/src/Thd/Commands/Compare/CompareCommand.cs
@@ -1,13 +1,26 @@
+using Thd.Request;
+
 namespace Thd.Commands.Compare;
 
 public sealed record CompareCommand
 {
     public required FileInfo SourceFile { get; init; }
-
     public required CompareConfiguration Configuration { get; init; }
-
     public required RequestConfiguration ActualRequestConfiguration { get; init; }
     public required RequestConfiguration ExpectedReportConfiguration { get; init; }
 }
 
-public sealed record CompareConfiguration(bool IsInteractive, bool ShouldNormalize);
+public sealed record CompareConfiguration(
+    bool IsInteractive,
+    bool ShouldNormalizeBaseUrlInResponse,
+    Filter Filter,
+    string? PathStartsWith,
+    bool UpgradeHttpToHttpInResponse
+);
+
+public enum Filter
+{
+    None,
+    Unique,
+    UniquePattern
+}

--- a/src/Thd/Commands/Compare/CompareRequestData.cs
+++ b/src/Thd/Commands/Compare/CompareRequestData.cs
@@ -1,0 +1,3 @@
+namespace Thd.Commands.Compare;
+
+public record CompareRequestData(ResolvedUrl UrlActual, ResolvedUrl UrlExpected);

--- a/src/Thd/Commands/Compare/ReplayData.cs
+++ b/src/Thd/Commands/Compare/ReplayData.cs
@@ -1,8 +1,0 @@
-namespace Thd.Commands.Compare;
-
-public record ReplayData
-{
-    public required string Path { get; init; }
-
-    public required IDictionary<string, string> RoutingData { get; init; }
-}

--- a/src/Thd/Program.cs
+++ b/src/Thd/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System.CommandLine;
 
-using Thd.Commands.Compare;
-
 namespace Thd;
 
 public sealed class Program

--- a/src/Thd/Reader/CsvReader.cs
+++ b/src/Thd/Reader/CsvReader.cs
@@ -1,0 +1,52 @@
+using System.Runtime.CompilerServices;
+
+using nietras.SeparatedValues;
+
+namespace Thd.Reader;
+
+/// <summary>
+/// Will read replay data from a CSV file
+/// The path needs to be located as the last column
+/// </summary>
+public class CsvReader : IReplayDataReader
+{
+    private readonly string _csvFilePath;
+
+    public CsvReader(string csvFilePath)
+    {
+        _csvFilePath = csvFilePath;
+    }
+
+    public async IAsyncEnumerable<ReplayData> Read([EnumeratorCancellation] CancellationToken token)
+    {
+
+        using var reader = await Sep.Reader(configure: options => options with
+        {
+            Unescape = true
+        }).FromFileAsync(_csvFilePath, token);
+
+        int numberOfMetaDataColumns = reader.Header.ColNames.Count - 1;
+
+        foreach (var readRow in reader)
+        {
+            yield return ReplayData(numberOfMetaDataColumns, readRow);
+        }
+    }
+
+    private static ReplayData ReplayData(int numberOfMetaDataColumns, SepReader.Row readRow)
+    {
+        IDictionary<string, string> routingData = new Dictionary<string, string>();
+        for (int i = 0; i < numberOfMetaDataColumns; i++)
+        {
+            routingData["column_" + (i + 1)] = readRow[i].Span.ToString();
+        }
+
+        var replayData = new ReplayData
+        {
+            Path = readRow[numberOfMetaDataColumns].Span.ToString(),
+            RoutingData = routingData
+        };
+
+        return replayData;
+    }
+}

--- a/src/Thd/Reader/IReplayDataReader.cs
+++ b/src/Thd/Reader/IReplayDataReader.cs
@@ -1,0 +1,6 @@
+namespace Thd.Reader;
+
+public interface IReplayDataReader
+{
+    IAsyncEnumerable<ReplayData> Read(CancellationToken token);
+}

--- a/src/Thd/Reader/IResolveUrl.cs
+++ b/src/Thd/Reader/IResolveUrl.cs
@@ -1,0 +1,8 @@
+using Thd.Commands.Compare;
+
+namespace Thd.Reader;
+
+public interface IResolveUrl
+{
+    public ResolvedUrl ResolveUrl(ReplayData url);
+}

--- a/src/Thd/Reader/ReplayData.cs
+++ b/src/Thd/Reader/ReplayData.cs
@@ -1,0 +1,17 @@
+namespace Thd.Reader;
+
+/// <summary>
+/// Main contract for source data in order to be able to compare requests
+/// </summary>
+public record ReplayData
+{
+    /// <summary>
+    /// Path and query for a request to be compared
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Data that will be available to for the template engine to build base urls e.g. column_1
+    /// </summary>
+    public required IDictionary<string, string> RoutingData { get; init; }
+}

--- a/src/Thd/Reader/TemplateUrlResolver.cs
+++ b/src/Thd/Reader/TemplateUrlResolver.cs
@@ -1,0 +1,28 @@
+using Scriban;
+
+namespace Thd.Reader;
+
+public sealed class TemplateUrlResolver : IResolveUrl
+{
+    private readonly Template _template;
+
+    public TemplateUrlResolver(string template)
+    {
+        _template = Template.Parse(template);
+    }
+
+    public ResolvedUrl ResolveUrl(ReplayData url)
+    {
+        string baseUrl = ParseBaseUrl(_template, url);
+
+        var destination = new Uri(baseUrl + url.Path);
+
+        return new ResolvedUrl(baseUrl, destination);
+    }
+
+    private static string ParseBaseUrl(Template template, ReplayData url)
+    {
+        var rendered = template.Render(url.RoutingData);
+        return rendered;
+    }
+}

--- a/src/Thd/Request/GetRequest.cs
+++ b/src/Thd/Request/GetRequest.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Nodes;
+
+using Thd.Commands.Compare;
+
+namespace Thd.Request;
+
+public class GetRequest
+{
+    private readonly HttpClient _httpClient;
+    private readonly RequestConfiguration _requestConfiguration;
+
+    public GetRequest(HttpClient httpClient, RequestConfiguration requestConfiguration)
+    {
+        _requestConfiguration = requestConfiguration ?? throw new ArgumentNullException(nameof(requestConfiguration));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public async Task<RequestResult> Get(ResolvedUrl url, ResponseConfiguration responseConfiguration,
+        CancellationToken token)
+    {
+        HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, url.DestinationUrl);
+        if (!string.IsNullOrWhiteSpace(_requestConfiguration.ApiKey))
+        {
+            httpRequestMessage.Headers.Add("Authorization", _requestConfiguration.ApiKey);
+        }
+
+        var response =
+            await _httpClient.SendAsync(httpRequestMessage, token);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return new RequestResult(url.DestinationUrl, null, response.StatusCode);
+        }
+
+        string responseContent = await response.Content.ReadAsStringAsync(token);
+
+        var normalizedResponse = responseConfiguration.ShouldUpgradeHttpToHttps
+            ? responseContent.Replace("http://", "https://")
+            : responseContent;
+
+        normalizedResponse = responseConfiguration.ShouldNormalizeBaseUrl
+            ? normalizedResponse
+                .Replace(url.BaseUrl, "")
+            : responseContent;
+
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+
+        var json = WrapResponse(mediaType, normalizedResponse);
+
+        var node = JsonNode.Parse(json);
+
+        return new RequestResult(url.DestinationUrl, node, response.StatusCode);
+    }
+
+    private string WrapResponse(string? mediaType, string response)
+    {
+        if (mediaType == null)
+        {
+            return """{ "value": null }""";
+        }
+
+        if (mediaType == "text/plain")
+        {
+            return $$$"""{ "value": "{{{response}}}" }""";
+        }
+
+        if (mediaType.Contains("json"))
+        {
+            return response;
+        }
+
+        return $$$"""{ "value": "{{{mediaType}}}" }""";
+    }
+}

--- a/src/Thd/Request/RegexOptions.cs
+++ b/src/Thd/Request/RegexOptions.cs
@@ -1,0 +1,9 @@
+using System.Text.RegularExpressions;
+
+namespace Thd.Request;
+
+internal static partial class RegexOptions
+{
+    [GeneratedRegex("""[\d]{2,}""")]
+    public static partial Regex CouldBeAnIdentifier();
+}

--- a/src/Thd/Request/RequestConfiguration.cs
+++ b/src/Thd/Request/RequestConfiguration.cs
@@ -1,4 +1,4 @@
-namespace Thd.Commands.Compare;
+namespace Thd.Request;
 
 public record RequestConfiguration
 {

--- a/src/Thd/Request/RequestResult.cs
+++ b/src/Thd/Request/RequestResult.cs
@@ -1,0 +1,6 @@
+using System.Net;
+using System.Text.Json.Nodes;
+
+namespace Thd.Request;
+
+public record RequestResult(Uri InspectionUrl, JsonNode? Node, HttpStatusCode StatusCode);

--- a/src/Thd/Request/ResponseConfiguration.cs
+++ b/src/Thd/Request/ResponseConfiguration.cs
@@ -1,0 +1,14 @@
+namespace Thd.Request;
+
+public record ResponseConfiguration
+{
+    /// <summary>
+    /// Will remove the base url from the returned response
+    /// </summary>
+    public bool ShouldNormalizeBaseUrl { get; init; }
+
+    /// <summary>
+    /// Some applications might return http instead of https in the response that will introduce a diff
+    /// </summary>
+    public bool ShouldUpgradeHttpToHttps { get; init; }
+}

--- a/src/Thd/Request/UrlFilter.cs
+++ b/src/Thd/Request/UrlFilter.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Text;
+
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
+
+namespace Thd.Request;
+
+public static class UrlFilter
+{
+    public static string GenerateUniqueKey(Uri url)
+    {
+        StringBuilder builder = new();
+        builder.Append(url.DnsSafeHost.ToLower(CultureInfo.InvariantCulture));
+
+        foreach (string urlSegment in url.Segments)
+        {
+            if (urlSegment == "/")
+            {
+                continue;
+            }
+
+            builder.Append('/');
+
+            if (RegexOptions.CouldBeAnIdentifier().IsMatch(urlSegment))
+            {
+                builder.Append("{id}");
+            }
+            else
+            {
+                builder.Append(urlSegment.Trim('/').ToLower(CultureInfo.InvariantCulture));
+            }
+        }
+
+        Dictionary<string, StringValues> dictionary = QueryHelpers.ParseQuery(url.Query);
+
+        foreach (string key in dictionary.Keys.Order())
+        {
+            builder.Append('?');
+            builder.Append(key.ToLower(CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Thd/ResolvedUrl.cs
+++ b/src/Thd/ResolvedUrl.cs
@@ -1,0 +1,3 @@
+namespace Thd;
+
+public record ResolvedUrl(string BaseUrl, Uri DestinationUrl);

--- a/src/Thd/Thd.csproj
+++ b/src/Thd/Thd.csproj
@@ -27,8 +27,11 @@
         <None Include="images/icon.png" Pack="true" PackagePath="/"/>
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
         <PackageReference Include="Scriban"/>
         <PackageReference Include="Sep"/>
+        <PackageReference Include="Spectre.Console"/>
+        <PackageReference Include="Spectre.Console.Json"/>
         <PackageReference Include="System.CommandLine"/>
         <PackageReference Include="SystemTextJson.JsonDiffPatch"/>
     </ItemGroup>

--- a/test/Thd.Test/Requests/UrlFilterTests.cs
+++ b/test/Thd.Test/Requests/UrlFilterTests.cs
@@ -1,0 +1,25 @@
+using Thd.Request;
+
+namespace Thd.Requests;
+
+public class UrlFilterTests
+{
+    [Theory]
+    [InlineData("https://www.google.com/", "www.google.com")]
+    [InlineData("https://www.google.com/bar", "www.google.com/bar")]
+    [InlineData("https://www.google.com/foo/bar", "www.google.com/foo/bar")]
+    [InlineData("https://www.google.com/foo?a=1", "www.google.com/foo?a")]
+    [InlineData("https://www.google.com/foo?a=1&b=2", "www.google.com/foo?a?b")]
+    [InlineData("https://www.google.com/foo?b=1&a=2", "www.google.com/foo?a?b")]
+    [InlineData("https://www.google.com/customer/1567", "www.google.com/customer/{id}")]
+    [InlineData("https://www.google.com/customer/1567/bar", "www.google.com/customer/{id}/bar")]
+    [InlineData("https://www.google.com/car/ABC-123/?extended=owners", "www.google.com/car/{id}?extended")]
+    public void ShouldGenerateUniqueKey(string url, string expected)
+    {
+        Uri uri = new Uri(url);
+
+        string key = UrlFilter.GenerateUniqueKey(uri);
+
+        Assert.Equal(expected, key);
+    }
+}

--- a/test/Thd.Test/Thd.Test.csproj
+++ b/test/Thd.Test/Thd.Test.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <RootNamespace>Thd</RootNamespace>
+        <!--
+        This template uses native xUnit.net command line options when using 'dotnet run' and
+        VSTest by default when using 'dotnet test'. For more information on how to enable support
+        for Microsoft Testing Platform, please visit:
+          https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+        -->
+        <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit.v3"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Thd\Thd.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Thd.Test/xunit.runner.json
+++ b/test/Thd.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/thd.slnx
+++ b/thd.slnx
@@ -5,4 +5,5 @@
     <File Path="Directory.Build.props" />
   </Folder>
   <Project Path="src\Thd\Thd.csproj" Type="Classic C#" />
+  <Project Path="test\Thd.Test\Thd.Test.csproj" Type="Classic C#" />
 </Solution>


### PR DESCRIPTION
### Changes

We have lots of requests with many permutations in the query parameters and we'll need to quickly figure out unique patterns for urls.

We would like to filter out requests to test a part of the api

In the responses we would like to remove the base url to limit the diff

Some old endpoints are buggy and return http in the response and we would like to upgrade them to https for the comparison

New experimental flags has been added to the `compare` command.

```
  --experimental-upgrade-http           Will upgrade http to https for the 
                                        actual responses
  --experimental-path                   Drop paths not starting with 
  <experimental-path>                   --experimental-path.
  --experimental-aggressive-filtering   Will find unique patterns in the actual 
                                        domain/path?query
```