### PR TITLE
Use stable version of dotnet 10

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.2.25502.107",
-    "rollForward": "latestPatch",
-    "allowPrerelease": true
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
### Changes
`10.0.100` has been released and there's no need to use the preview anymore.

### References
https://dotnet.microsoft.com/en-us/download/dotnet/10.0