### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,14 @@ jobs:
         run: dotnet format --no-restore --verify-no-changes
       - name: Build
         run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-restore --report-xunit-trx --results-directory artifacts/test-results
+      - name: Upload dotnet test results
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results
+          path: artifacts/test-results
+        if: ${{ always() }}  
   publish:
     if: startsWith(github.event.ref, 'refs/tags/v')
     environment: nuget

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,14 +5,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
     <PackageVersion Include="Scriban" Version="6.5.0" />
     <PackageVersion Include="Sep" Version="0.11.5" />
     <PackageVersion Include="Spectre.Console" Version="0.53.0" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.53.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="SystemTextJson.JsonDiffPatch" Version="2.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.0" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.100",
     "rollForward": "latestFeature"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/Thd/Thd.csproj
+++ b/src/Thd/Thd.csproj
@@ -17,6 +17,8 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ViaEuropa/thd.git</RepositoryUrl>
         <PackageIcon>icon.png</PackageIcon>
+        <!-- Once SystemTextJson.JsonDiffPatch drops the dependency on System.Text.Json i can be removed -->
+        <NoWarn>NU1510</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
@@ -33,6 +35,7 @@
         <PackageReference Include="Spectre.Console"/>
         <PackageReference Include="Spectre.Console.Json"/>
         <PackageReference Include="System.CommandLine"/>
+        <PackageReference Include="System.Text.Json" />
         <PackageReference Include="SystemTextJson.JsonDiffPatch"/>
     </ItemGroup>
 </Project>

--- a/test/Thd.Test/Thd.Test.csproj
+++ b/test/Thd.Test/Thd.Test.csproj
@@ -12,19 +12,14 @@
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
-
+    
     <ItemGroup>
-        <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit.v3"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Thd.Test/xunit.runner.json
+++ b/test/Thd.Test/xunit.runner.json
@@ -1,3 +1,0 @@
-{
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
-}


### PR DESCRIPTION
### Changes

- https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
- Direct dependency on `System.Text.Json` to override transitive dependency until it has been upgraded


```
» thd
  [net10.0]
  Microsoft.AspNetCore.WebUtilities  9.0.10               -> 10.0.0
  Scriban                            6.4.0                -> 6.5.0
  Sep                                0.11.3               -> 0.11.5
  System.CommandLine                 2.0.0-rc.2.25502.107 -> 2.0.0

» Thd.Test
  [net10.0]
  Microsoft.NET.Test.Sdk  17.13.0 -> 18.0.1
  xunit.v3                3.1.0   -> 3.2.0
```