### PR TITLE
Add a verbosity option to display request meta data on success

### DIFF
--- a/src/Thd/Commands/Compare/CompareCommand.cs
+++ b/src/Thd/Commands/Compare/CompareCommand.cs
@@ -15,8 +15,8 @@ public sealed record CompareConfiguration(
     bool ShouldNormalizeBaseUrlInResponse,
     Filter Filter,
     string? PathStartsWith,
-    bool UpgradeHttpToHttpInResponse
-);
+    bool UpgradeHttpToHttpInResponse,
+    Verbosity Verbosity);
 
 public enum Filter
 {

--- a/src/Thd/Commands/Compare/Diff.cs
+++ b/src/Thd/Commands/Compare/Diff.cs
@@ -45,7 +45,7 @@ public static class Diff
         }
 
         // Detailed rendering of the requests
-        if (!identicalRequests)
+        if (!identicalRequests || configuration.Verbosity.IsAtLeastDetailed())
         {
             RenderRequestData(console, expectedResult, "Expected");
             RenderRequestData(console, actualResult, "Actual");

--- a/src/Thd/Verbosity.cs
+++ b/src/Thd/Verbosity.cs
@@ -1,0 +1,10 @@
+namespace Thd;
+
+public enum Verbosity
+{
+    Quiet = 0,
+    Minimal = 1,
+    Normal = 2,
+    Detailed = 3,
+    Diagnostic = 4
+}

--- a/src/Thd/VerbosityExtensions.cs
+++ b/src/Thd/VerbosityExtensions.cs
@@ -1,0 +1,18 @@
+namespace Thd;
+
+public static class VerbosityExtensions
+{
+    extension(Verbosity verbosity)
+    {
+        /// <summary>
+        /// Checks if the verbosity is at least Detailed or Diagnostic
+        /// </summary>
+        /// <returns>true if the verbosity is detailed</returns>
+        public bool IsAtLeastDetailed() => verbosity.IsAtLeast(Verbosity.Detailed);
+
+        private bool IsAtLeast(Verbosity level)
+        {
+            return verbosity >= level;
+        }
+    }
+}

--- a/test/Thd.Test/CompareIntegrationTests.Compare_HappyFlow_Verbose.verified.txt
+++ b/test/Thd.Test/CompareIntegrationTests.Compare_HappyFlow_Verbose.verified.txt
@@ -1,0 +1,5 @@
+﻿✅ /version
+  Expected (Status OK)
+    http://localhost:5000/version
+  Actual (Status OK)
+    http://localhost:5000/version

--- a/test/Thd.Test/CompareIntegrationTests.cs
+++ b/test/Thd.Test/CompareIntegrationTests.cs
@@ -40,6 +40,34 @@ public class CompareIntegrationTests
     }
 
     [Fact]
+    public async Task Compare_HappyFlow_Verbose()
+    {
+        const string content = """
+                               Id;Path
+                               1;/version
+                               """;
+
+        string sourceFile = await CreateSourceFile(content, TestContext.Current.CancellationToken);
+
+        string[] args =
+        [
+            "compare",
+            "-l",
+            _apiFixture.BasePath,
+            "-r",
+            _apiFixture.BasePath,
+            "--verbosity",
+            "detailed",
+            sourceFile
+        ];
+
+        ExecResult result = await ExecThd(args);
+
+        Assert.Equal(0, result.ExitCode);
+        await Verify(result.StdOut);
+    }
+
+    [Fact]
     public async Task Compare_StatusCodeDiff()
     {
         const string content = """


### PR DESCRIPTION
Setting the `--verbosity detailed` option will print request meta data e.g.

```
✅ /version
  Expected (Status OK)
    http://localhost:5000/version
  Actual (Status OK)
    http://localhost:5000/version
```

Resolves #18 