### PR TITLE
Improved http status diff

### DIFF
--- a/src/Thd/Commands/Compare/Diff.cs
+++ b/src/Thd/Commands/Compare/Diff.cs
@@ -62,7 +62,16 @@ public static class Diff
 
         if (expectedStatusCode != expectedResult.StatusCode || expectedStatusCode != actualResult.StatusCode)
         {
-            console.WriteLine($"  HTTP status diff: {expectedStatusCode} !== {actualResult.StatusCode}");
+            console.Write("  HTTP status diff:");
+            if (expectedStatusCode != expectedResult.StatusCode)
+            {
+                console.Write($" (Expected {expectedResult.StatusCode} !== {expectedStatusCode})");
+            }
+            if (expectedStatusCode != actualResult.StatusCode)
+            {
+                console.Write($" (Actual {actualResult.StatusCode} !== {expectedStatusCode})");
+            }
+            console.WriteLine();
         }
 
         var diff = expectedResult.Node.Diff(actualResult.Node);

--- a/src/Thd/Reader/HttpStatusCodeTemplateResolver.cs
+++ b/src/Thd/Reader/HttpStatusCodeTemplateResolver.cs
@@ -25,7 +25,7 @@ public sealed class HttpStatusCodeTemplateResolver : IHttpStatusCodeResolver
         {
             return null;
         }
-        
+
         return (HttpStatusCode)httpStatusCodeInt;
     }
 }

--- a/test/Thd.Test/CompareIntegrationTests.Compare_HappyFlow_ExpectedStatusCode.verified.txt
+++ b/test/Thd.Test/CompareIntegrationTests.Compare_HappyFlow_ExpectedStatusCode.verified.txt
@@ -4,4 +4,4 @@
     http://localhost:5000/version
   Actual (Status OK)
     http://localhost:5000/version
-  HTTP status diff: NotFound !== OK
+  HTTP status diff: (Expected OK !== NotFound) (Actual OK !== NotFound)

--- a/test/Thd.Test/CompareIntegrationTests.Compare_NoServer.verified.txt
+++ b/test/Thd.Test/CompareIntegrationTests.Compare_NoServer.verified.txt
@@ -3,7 +3,7 @@
     http://localhost:5000/version
   Actual (Status N/A) - Error: ConnectionError
     https://localhost:1567/version
-  HTTP status diff: OK !== 
+  HTTP status diff: (Actual  !== OK)
   JSON diff:
 [
    {

--- a/test/Thd.Test/CompareIntegrationTests.Compare_StatusCodeDiff.verified.txt
+++ b/test/Thd.Test/CompareIntegrationTests.Compare_StatusCodeDiff.verified.txt
@@ -3,7 +3,7 @@
     http://localhost:5000/version
   Actual (Status NotFound)
     http://localhost:5000/notfound/version
-  HTTP status diff: OK !== NotFound
+  HTTP status diff: (Actual NotFound !== OK)
   JSON diff:
 [
    {


### PR DESCRIPTION
Since we can specify an expected http status code we'll need to reflect that in the diff.
At the moment it's hard to understand the diff e.g.
`HTTP status diff: NotFound !== OK`
after this change:
`HTTP status diff: (Expected OK !== NotFound) (Actual OK !== NotFound)`

Now which endpoint that have a different value from the expected