### PR TITLE
Upgrade dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,17 +5,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
-    <PackageVersion Include="Scriban" Version="6.5.2" />
-    <PackageVersion Include="Sep" Version="0.12.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageVersion Include="Scriban" Version="7.0.3" />
+    <PackageVersion Include="Sep" Version="0.12.3" />
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.54.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.2" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.2" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.5" />
     <PackageVersion Include="SystemTextJson.JsonDiffPatch" Version="2.0.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.10.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.13.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Changes

This PR updates centrally-managed NuGet package versions to newer patch/minor releases for the thd .NET tool (net10.0), primarily covering ASP.NET utilities, testing/coverage, templating, CSV parsing, command-line parsing, JSON, and snapshot testing.

Changes:

Bump Microsoft.AspNetCore.WebUtilities and System.Text.Json from 10.0.2 → 10.0.5
Update test/coverage-related packages (Microsoft.Testing.Extensions.CodeCoverage, Verify.XunitV3)
Upgrade Scriban, Sep, and System.CommandLine to newer releases